### PR TITLE
Mutations! 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
         "@types/express": "^4.17.13",
         "@types/filesystem": "^0.0.32",
         "@types/turndown": "^5.0.1",
+        "axios": "^0.21.1",
+        "crypto-js": "^4.1.1",
         "discord-api-types": "^0.22.0",
         "discord.js": "^13.1.0",
         "dotenv": "^10.0.0",
@@ -1626,6 +1628,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
     },
     "node_modules/culvert": {
       "version": "0.1.2",
@@ -6917,6 +6924,11 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
+    },
+    "crypto-js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
     },
     "culvert": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "@types/express": "^4.17.13",
     "@types/filesystem": "^0.0.32",
     "@types/turndown": "^5.0.1",
+    "axios": "^0.21.1",
+    "crypto-js": "^4.1.1",
     "discord-api-types": "^0.22.0",
     "discord.js": "^13.1.0",
     "dotenv": "^10.0.0",

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -1,0 +1,42 @@
+// import types
+import { SlashCommandStringOption } from '@discordjs/builders'
+import { CommandInteraction } from 'discord.js'
+
+import { getAuthUser, isAuthenticated } from '../requests/anilist'
+import { AniMedia } from '../types'
+const { SlashCommandBuilder } = require('@discordjs/builders')
+const { GET_MEDIA } = require('../queries')
+const { ADD } = require('../mutations')
+const { GraphQLClient } = require('graphql-request')
+const client = new GraphQLClient('https://graphql.anilist.co')
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('add')
+    .setDescription('Add an anime to your AniList (MUST BE AUTHENTICATED)')
+    .addStringOption((opt: SlashCommandStringOption) =>
+      opt
+        .setName('anime')
+        .setDescription('Anime title')
+        .setRequired(true)
+    ),
+  async execute (interaction: CommandInteraction) {
+    const title = interaction.options.getString('anime')
+    const discord = interaction.user.id
+    if (await isAuthenticated(discord)) {
+      const authUser = await getAuthUser(discord)
+      const headers = authUser.headers
+      try {
+        const anime: AniMedia = await client.request(GET_MEDIA, { search: title })
+        const id = anime.Media.id
+        await client.request(ADD, { mediaId: id }, headers)
+        interaction.reply({ content: `<@${discord}> added [**${anime.Media.title.romaji}**](${anime.Media.siteUrl}) to their anime list.` })
+      } catch (err) {
+        console.error(err)
+        interaction.reply({ content: 'Error - does this anime exist on AniList?', ephemeral: true })
+      }
+    } else {
+      interaction.reply({ content: 'You are not authenticated! `/link`', ephemeral: true })
+    }
+  }
+}

--- a/src/commands/link.ts
+++ b/src/commands/link.ts
@@ -1,0 +1,63 @@
+// import types
+import { CommandInteraction, Message, MessageActionRow, MessageEmbed } from 'discord.js'
+import { authenticate } from '../requests/anilist'
+import { AniUser, Viewer } from '../types'
+
+const Discord = require('discord.js')
+const { SlashCommandBuilder } = require('@discordjs/builders')
+const { GraphQLClient } = require('graphql-request')
+const client = new GraphQLClient('https://graphql.anilist.co')
+const { GET_USERINFO } = require('../queries')
+
+const conn = require('../connections/anidata_conn')
+const Alias = conn.models.Alias
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('link')
+    .setDescription('Link your AniList to your Discord.'),
+  async execute (interaction: CommandInteraction) {
+    const row: MessageActionRow = new Discord.MessageActionRow()
+      .addComponents(
+        new Discord.MessageButton()
+          .setLabel('Link your AniList')
+          .setURL(`https://anilist.co/api/v2/oauth/authorize?client_id=${process.env.ANI_CLIENT}&response_type=token`)
+          .setStyle('LINK')
+      )
+    interaction.reply({ content: 'Check DMs!', ephemeral: true })
+    const reply = await interaction.user.send({ content: 'Click the button below and follow the link to the AniList authentication page. Follow the prompts to log-in if necessary, and then copy the long code. Paste the code you received here!', components: [row] })
+
+    const filter = async (m: Message) => {
+      const token = m.content
+      const user: Viewer = await authenticate(token, m.author.id)
+      const userInfo: AniUser = await client.request(GET_USERINFO, { name: user.name })
+      m.reply('Success! Your token will be encrypted and securely stored so that you can execute AniList-authenticated actions through Discord! Feel free to delete your token from this chat.')
+      const embed: MessageEmbed = new Discord.MessageEmbed()
+        .setDescription(`<@${interaction.user.id}> just linked their account to AniList user [**${user.name}**](${userInfo.User.siteUrl})!`)
+      interaction.followUp({ embeds: [embed] })
+
+      // ADD/EDIT ALIAS
+      const query = { 'server.serverId': interaction.guildId }
+      const countServerDocs: number = await Alias.find(query).limit(1).countDocuments()
+      if (countServerDocs === 0) {
+        const newServer = new Alias({
+          server: {
+            serverId: interaction.guildId,
+            users: []
+          }
+        })
+        await newServer.save()
+      }
+      const newUser = {
+        username: user.name,
+        userId: `<@!${interaction.user.id}>`
+      }
+      const eraseOld = { userId: `<@!${interaction.user.id}>` }
+      await Alias.findOneAndUpdate(query, { $pull: { 'server.users': eraseOld } })
+      await Alias.findOneAndUpdate(query, { $push: { 'server.users': newUser } }, { new: true })
+
+      return token.length > 50
+    }
+    reply.channel.awaitMessages({ filter, max: 1, time: 180000, errors: ['time'] })
+  }
+}

--- a/src/commands/subcommands/update/episodes.ts
+++ b/src/commands/subcommands/update/episodes.ts
@@ -1,0 +1,77 @@
+import { CommandInteraction, Message, MessageActionRow, MessageButton, MessageComponentInteraction, MessageEmbed } from 'discord.js'
+import { getAuthUser } from '../../../requests/anilist'
+import { AniList, AniMedia } from '../../../types'
+const { GET_MEDIALIST, GET_MEDIA } = require('../../../queries')
+const { INCREMENT_EP } = require('../../../mutations')
+const { GraphQLClient } = require('graphql-request')
+const client = new GraphQLClient('https://graphql.anilist.co')
+
+module.exports = {
+  data: {
+    name: 'episodes'
+  },
+  async execute (interaction: CommandInteraction, discord: string, title: string, embed: MessageEmbed, reply: Message) {
+    const anime: AniMedia = await client.request(GET_MEDIA, { search: title })
+
+    const authUser = await getAuthUser(discord)
+    const headers = authUser.headers
+    const username = authUser.username
+
+    try {
+      const listEntry: AniList = await client.request(GET_MEDIALIST, { userName: username, mediaId: anime.Media.id })
+      let currentProgress = listEntry.MediaList.progress
+
+      const math: MessageActionRow = new MessageActionRow()
+        .addComponents(
+          new MessageButton()
+            .setLabel('+')
+            .setCustomId('add')
+            .setStyle('SUCCESS'),
+          new MessageButton()
+            .setLabel('-')
+            .setCustomId('subtract')
+            .setStyle('DANGER')
+        )
+      interaction.editReply({ embeds: [embed], components: [math] })
+
+      const filter = async (i: MessageComponentInteraction) => {
+        if (i.user.id !== interaction.user.id) {
+          i.reply({ content: 'This button is not for you!', ephemeral: true })
+        } else {
+          if (i.customId === 'add') {
+            const progToSet = currentProgress + 1
+            if (progToSet > listEntry.MediaList.media.episodes) {
+              i.reply({
+                content: `You tried to set your ep. count for [**${anime.Media.title.romaji}**](${anime.Media.siteUrl}) to ${progToSet}, but it only has ${listEntry.MediaList.media.episodes} episodes!`,
+                ephemeral: true
+              })
+            } else {
+              await client.request(INCREMENT_EP, { mediaId: anime.Media.id, progress: progToSet }, headers)
+              embed.spliceFields(0, 1, { name: 'Progress:', value: `${progToSet}/${anime.Media.episodes}`, inline: true })
+              currentProgress = progToSet
+              i.deferUpdate()
+              interaction.editReply({ embeds: [embed] })
+            }
+          } else if (i.customId === 'subtract') {
+            if (currentProgress === 0) {
+              i.reply({ content: 'You\'re already at 0!', ephemeral: true })
+            } else {
+              const progToSet = currentProgress - 1
+              await client.request(INCREMENT_EP, { mediaId: anime.Media.id, progress: progToSet }, headers)
+              embed.spliceFields(0, 1, { name: 'Progress:', value: `${progToSet}/${anime.Media.episodes}`, inline: true })
+              currentProgress = progToSet
+              i.deferUpdate()
+              interaction.editReply({ embeds: [embed] })
+            }
+          }
+        }
+        return i.user.id === interaction.user.id
+      }
+      reply.createMessageComponentCollector({ filter, componentType: 'BUTTON', time: 30000 })
+    } catch (err) {
+      console.error(err)
+      console.error(username, 'failed to use /update episodes with query', title)
+      interaction.reply({ content: `Command failed. Make sure you have an existing list entry for [**${anime.Media.title.romaji}**](${anime.Media.siteUrl}).`, ephemeral: true })
+    }
+  }
+}

--- a/src/commands/subcommands/update/rate.ts
+++ b/src/commands/subcommands/update/rate.ts
@@ -1,0 +1,90 @@
+import { CommandInteraction, Message, MessageActionRow, MessageEmbed, MessageSelectMenu, SelectMenuInteraction } from 'discord.js'
+import { getAuthUser } from '../../../requests/anilist'
+import { AniMedia } from '../../../types'
+const { GET_MEDIA } = require('../../../queries')
+const { RATE } = require('../../../mutations')
+const { GraphQLClient } = require('graphql-request')
+const client = new GraphQLClient('https://graphql.anilist.co')
+
+module.exports = {
+  data: {
+    name: 'rate'
+  },
+  async execute (interaction: CommandInteraction, discord: string, title: string, embed: MessageEmbed, _reply: Message) {
+    const anime: AniMedia = await client.request(GET_MEDIA, { search: title })
+
+    const authUser = await getAuthUser(discord)
+    const headers = authUser.headers
+
+    const ratings = new MessageActionRow()
+      .addComponents(
+        new MessageSelectMenu()
+          .setCustomId('select')
+          .setPlaceholder('Nothing selected')
+          .addOptions([
+            {
+              label: '0',
+              value: '0'
+            },
+            {
+              label: '1',
+              value: '1'
+            },
+            {
+              label: '2',
+              value: '2'
+            },
+            {
+              label: '3',
+              value: '3'
+            },
+            {
+              label: '4',
+              value: '4'
+            },
+            {
+              label: '5',
+              value: '5'
+            },
+            {
+              label: '6',
+              value: '6'
+            },
+            {
+              label: '7',
+              value: '7'
+            },
+            {
+              label: '8',
+              value: '8'
+            },
+            {
+              label: '9',
+              value: '9'
+            },
+            {
+              label: '10',
+              value: '10'
+            }
+          ])
+      )
+    interaction.editReply({ components: [] })
+    const menu = await interaction.followUp({ content: 'Select a rating', components: [ratings] }) as Message
+
+    const filter = async (i: SelectMenuInteraction) => {
+      if (i.user.id !== interaction.user.id) {
+        i.reply({ content: 'This menu is not for you!', ephemeral: true })
+      } else {
+        const score = Number(i.values[0])
+        await client.request(RATE, { mediaId: anime.Media.id, score: score }, headers)
+        embed.spliceFields(1, 1, { name: 'Rating', value: `${score}/10`, inline: true })
+        i.deferUpdate()
+        menu.delete()
+        interaction.editReply({ embeds: [embed] })
+        setTimeout(() => interaction.deleteReply(), 5000)
+      }
+      return i.user.id === interaction.user.id
+    }
+    menu.awaitMessageComponent({ filter, componentType: 'SELECT_MENU', time: 30000 })
+  }
+}

--- a/src/commands/unlink.ts
+++ b/src/commands/unlink.ts
@@ -1,0 +1,22 @@
+// import types
+import { CommandInteraction } from 'discord.js'
+import { removeAuthentication, isAuthenticated, getAuthUser } from '../requests/anilist'
+
+const { SlashCommandBuilder } = require('@discordjs/builders')
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('unlink')
+    .setDescription('Unlink your AniList from your Discord.'),
+  async execute (interaction: CommandInteraction) {
+    const discord = interaction.user.id
+    if (await isAuthenticated(discord)) {
+      const auth = await getAuthUser(discord)
+      const anilist = auth.username
+      await removeAuthentication(discord)
+      interaction.reply({ content: `You are no longer logged in as ${anilist}.`, ephemeral: true })
+    } else {
+      interaction.reply({ content: 'You aren\'t currently logged in as any AniList user.' })
+    }
+  }
+}

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,0 +1,87 @@
+// import types
+import { SlashCommandStringOption } from '@discordjs/builders'
+import { CommandInteraction, Message, MessageActionRow, MessageButton, MessageComponentInteraction, MessageEmbed } from 'discord.js'
+
+import { getAuthUser, isAuthenticated } from '../requests/anilist'
+import { AniList, AniMedia } from '../types'
+const { SlashCommandBuilder } = require('@discordjs/builders')
+const { Collection } = require('discord.js')
+const { GET_MEDIALIST, GET_MEDIA } = require('../queries')
+const { GraphQLClient } = require('graphql-request')
+const client = new GraphQLClient('https://graphql.anilist.co')
+const fs = require('fs')
+const path = require('path')
+const subcommands = new Collection()
+const subFiles = fs.readdirSync(path.resolve(__dirname, './subcommands/update')).filter((file: string) => file.endsWith('.ts'))
+
+for (const file of subFiles) {
+  const command = require(`./subcommands/update/${file}`)
+  subcommands.set(command.data.name, command)
+}
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('update')
+    .setDescription('Update an AniList entry (MUST BE AUTHENTICATED)')
+    .addStringOption((opt: SlashCommandStringOption) =>
+      opt
+        .setName('anime')
+        .setDescription('Anime title')
+        .setRequired(true)
+    ),
+  async execute (interaction: CommandInteraction) {
+    const discord = interaction.user.id
+    const title = interaction.options.getString('anime')
+    const anime: AniMedia = await client.request(GET_MEDIA, { search: title })
+    const id = anime.Media.id
+    if (await isAuthenticated(discord)) {
+      const authUser = await getAuthUser(discord)
+      const username = authUser.username
+      try {
+        const listEntry: AniList = await client.request(GET_MEDIALIST, { userName: username, mediaId: id })
+        const row: MessageActionRow = new MessageActionRow()
+          .addComponents(
+            new MessageButton()
+              .setLabel('Episode Count')
+              .setCustomId('episodes')
+              .setStyle('PRIMARY'),
+            new MessageButton()
+              .setLabel('Rate')
+              .setCustomId('rate')
+              .setStyle('PRIMARY')
+          )
+        const embed: MessageEmbed = new MessageEmbed()
+          .setTitle(anime.Media.title.romaji)
+          .setThumbnail(anime.Media.coverImage.large)
+          .setDescription(`Update your AniList entry on [**${anime.Media.title.romaji}**](${anime.Media.siteUrl})`)
+          .addField('Progress:', `${listEntry.MediaList.progress}/${anime.Media.episodes}`, true)
+        if (listEntry.MediaList.status === 'COMPLETED') {
+          embed.addField('Rating:', `${listEntry.MediaList.score}/10`, true)
+        } else {
+          embed.addField('Rating:', `${listEntry.MediaList.score}/10 (unfinished)`, true)
+        }
+
+        interaction.reply({ embeds: [embed], components: [row] })
+        const reply = await interaction.fetchReply() as Message
+
+        const filter = async (i: MessageComponentInteraction) => {
+          if (i.user.id !== interaction.user.id) {
+            i.reply({ content: 'This button is not for you!', ephemeral: true })
+          } else {
+            i.deferUpdate()
+            await subcommands.get(i.customId).execute(interaction, discord, title, embed, reply)
+          }
+          return i.user.id === interaction.user.id
+        }
+        reply.awaitMessageComponent({ filter, componentType: 'BUTTON', time: 30000 })
+        setTimeout(() => {
+          interaction.deleteReply()
+        }, 30000)
+      } catch {
+        interaction.reply({ content: `Make sure you have an existing AniList entry for [**${anime.Media.title.romaji}**](${anime.Media.siteUrl}).`, ephemeral: true })
+      }
+    } else {
+      interaction.reply({ content: 'You are not authenticated! `/link`', ephemeral: true })
+    }
+  }
+}

--- a/src/connections/anidata_conn.ts
+++ b/src/connections/anidata_conn.ts
@@ -3,5 +3,6 @@ const mongoose = require('mongoose')
 const conn = mongoose.createConnection(process.env.MONGO_URL, { useNewUrlParser: true, useUnifiedTopology: true, useFindAndModify: false, useCreateIndex: true })
 conn.model('Alias', require('../schema/alias_model'))
 conn.model('Party', require('../schema/party_model'))
+conn.model('Auth', require('../schema/auth_model'))
 
 module.exports = conn

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ client.on('messageCreate', async (message: Message) => {
       try {
         console.log('Started refreshing slash commands...')
         await rest.put(
-          Routes.applicationGuildCommands(process.env.CLIENT_ID, process.env.GUILD_ID),
+          Routes.applicationCommands(process.env.CLIENT_ID),
           { body: commands }
         )
         console.log('Successfully refreshed slash commands!')

--- a/src/mutations.ts
+++ b/src/mutations.ts
@@ -1,0 +1,27 @@
+const { gql } = require('graphql-request')
+
+module.exports = {
+  INCREMENT_EP: gql`
+  mutation ($mediaId: Int, $progress: Int) {
+    SaveMediaListEntry (mediaId: $mediaId, progress: $progress) {
+      id
+      progress
+    }
+  }
+  `,
+  RATE: gql`
+  mutation ($mediaId: Int, $score: Float) {
+    SaveMediaListEntry (mediaId: $mediaId, score: $score) {
+      id
+      score
+    }
+  }
+  `,
+  ADD: gql`
+  mutation($mediaId: Int) {
+    SaveMediaListEntry (mediaId: $mediaId) {
+      id
+    }
+  }
+  `
+}

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -1,3 +1,4 @@
+export {}
 const { gql } = require('graphql-request')
 
 module.exports = {
@@ -110,6 +111,14 @@ module.exports = {
       image {
         large
       }
+    }
+  }
+  `,
+  GET_VIEWER: gql`
+  query {
+    Viewer {
+      name
+      id
     }
   }
   `

--- a/src/requests/anilist.ts
+++ b/src/requests/anilist.ts
@@ -1,0 +1,68 @@
+
+const { GET_VIEWER } = require('../queries')
+const axios = require('axios')
+const crypto = require('crypto-js')
+
+const conn = require('../connections/anidata_conn')
+const Auth = conn.models.Auth
+
+export const authenticate = async (token: string, discord: string) => {
+  const encrypted = crypto.AES.encrypt(token, process.env.CRY_SECRET).toString()
+
+  const res = await axios({
+    method: 'post',
+    url: `https://graphql.anilist.co?query=${GET_VIEWER}`,
+    headers: {
+      Authorization: 'Bearer ' + token,
+      'Content-Type': 'application/json',
+      Accept: 'application/json'
+    }
+  })
+  const query = { 'user.discord': discord }
+  const existing = await Auth.find(query)
+  const count: number = await Auth.find(query).limit(1).countDocuments()
+
+  if (count > 0) {
+    existing[0].token = encrypted
+    existing[0].user.anilist = res.data.data.Viewer.name
+  } else {
+    const newUser = new Auth({
+      token: encrypted,
+      user: {
+        discord: discord,
+        anilist: res.data.data.Viewer.name
+      }
+    })
+    await newUser.save()
+  }
+  return res.data.data.Viewer
+}
+
+export const removeAuthentication = async (discord: string) => {
+  const query = { 'user.discord': discord }
+  await Auth.deleteOne(query)
+}
+
+export const isAuthenticated = async (discord: string) => {
+  const query = { 'user.discord': discord }
+  const count: number = await Auth.find(query).limit(1).countDocuments()
+  return (count > 0)
+}
+
+export const getAuthUser = async (discord: string) => {
+  const query = { 'user.discord': discord }
+  const authDoc = await Auth.find(query)
+
+  const encrypted = authDoc[0].token
+  const token = crypto.AES.decrypt(encrypted, process.env.CRY_SECRET).toString(crypto.enc.Utf8)
+
+  const headers = {
+    Authorization: 'Bearer ' + token,
+    'Content-Type': 'application/json',
+    Accept: 'application/json'
+  }
+
+  const username = authDoc[0].user.anilist
+
+  return { headers, username }
+}

--- a/src/schema/auth_model.ts
+++ b/src/schema/auth_model.ts
@@ -1,0 +1,12 @@
+export {}
+const mongoose = require('mongoose')
+
+const authSchema = new mongoose.Schema({
+  token: String,
+  user: {
+    discord: String,
+    anilist: String
+  }
+})
+
+module.exports = authSchema

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,6 +95,11 @@ export interface AniMedia {
   }
 }
 
+export interface Viewer {
+  name: string;
+  id: number;
+}
+
 export interface Aliases {
   server: {
     serverId: string;


### PR DESCRIPTION
## [Mutations](https://anilist.gitbook.io/anilist-apiv2-docs/overview/graphql/mutations)
- `/link` prompts a user to log-in to AniList and authenticate (token is encrypted before storing in MongoDB) their Discord profile, allowing them to perform mutations straight from a Discord server (`/unlink` clears their token from memory)
- `/update` allows users to increment/decrement episodes, or change the rating of a given anime
- `/add` allows users to add a new anime to their list
- Linking an AniList account also automatically updates/creates a new alias for the user - to provide the user with options, alias will remain fully functional and the main basis for commands like `/url`, `/wp`, `/progress`, etc.

### Note
This is a large update, and particularly sensitive security-wise.  A lot of time went into guaranteeing the safety of the user's details, and ensuring that only the user could alter their AniList data. Nevertheless, other bugs (hopefully mostly UI-related) will be likely as there's only so much testing I can do with 1-2 dummy users. This PR will help see how the update scales. 